### PR TITLE
(#8) Fix environment failures and add environment to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,8 +60,18 @@ Ready to contribute? Here's how to set up BioProv for local development.
 git clone git@github.com:your_name_here/BioProv.git
 ```
 
-* Create a development environment. This can be done many different ways, such as with
-    [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) and [venv](https://docs.python.org/3/library/venv.html). Study carefully which one works best for your purposes.
+* Create a development environment. If you aren't yet familiar, get to know [conda](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html), the software used to manage our environment.
+
+```bash
+conda env create --file environment.yml
+```
+
+In case you've already created the environment and changes have been made to it, run:
+
+```bash
+conda activate bioprov
+conda env update --file environment.yml
+```
 
 * Assuming you've created the environment, install the package locally:
 
@@ -70,12 +80,6 @@ pip install -e .
 ```
 
 This will make an "editable" version of the local installation.
-
-* Download the black code styling tool:
-
-```bash
-pip install black 
-```
 
 * Update the repository to its latest version:
 
@@ -99,7 +103,7 @@ pytest
 ```
 
 Some tests will require external tools, such as [Prodigal](https://github.com/hyattpd/Prodigal),
-you can either download them or run only a subset of tests, such as:
+and if you haven't yet, you can either download them or run only a subset of tests, such as:
 
 ```bash
 pytest bioprov/tests/test_bioprov_imports.py 

--- a/environment.yml
+++ b/environment.yml
@@ -1,68 +1,133 @@
 name: bioprov
 channels:
+  - salilab
   - conda-forge
   - bioconda
   - defaults
 dependencies:
-  - ca-certificates=2020.6.20=hecda079_0
-  - certifi=2020.6.20=py37h2987424_2
-  - libcxx=11.0.0=h439d374_0
-  - libffi=3.2.1=hb1e8313_1007
-  - ncurses=6.2=hb1e8313_2
-  - openssl=1.1.1h=haf1e3a3_0
-  - pip=20.2.3=py_0
-  - prodigal=2.6.3=h01d97ff_2
-  - python=3.7.8=hc9dea61_1_cpython
-  - python_abi=3.7=1_cp37m
-  - readline=8.0=h0678c8f_2
-  - setuptools=49.6.0=py37h2987424_2
-  - sqlite=3.33.0=h960bd1c_1
-  - tk=8.6.10=hb0a8c7a_1
-  - wheel=0.35.1=pyh9f0ad1d_0
-  - xz=5.2.5=haf1e3a3_1
-  - zlib=1.2.11=h7795811_1010
+  - _libgcc_mutex=0.1
+  - _openmp_mutex=4.5
+  - argon2-cffi=20.1.0
+  - async_generator=1.10
+  - attrs=20.2.0
+  - backports=1.0
+  - backports.functools_lru_cache=1.6.1
+  - bleach=3.2.1
+  - brotlipy=0.7.0
+  - ca-certificates=2020.6.20
+  - certifi=2020.6.20
+  - cffi=1.14.3
+  - chardet=3.0.4
+  - cryptography=3.1.1
+  - decorator=4.4.2
+  - defusedxml=0.6.0
+  - entrypoints=0.3
+  - idna=2.10
+  - importlib-metadata=2.0.0
+  - importlib_metadata=2.0.0
+  - ipykernel=5.3.4
+  - ipython=5.8.0
+  - ipython_genutils=0.2.0
+  - jinja2=2.11.2
+  - json5=0.9.5
+  - jsonschema=3.2.0
+  - jupyter_client=6.1.7
+  - jupyter_core=4.6.3
+  - jupyterlab=2.2.8
+  - jupyterlab_pygments=0.1.2
+  - jupyterlab_server=1.2.0
+  - ld_impl_linux-64=2.35
+  - libcxx=11.0.0
+  - libcxxabi=11.0.0
+  - libffi=3.2.1
+  - libgcc-ng=9.3.0
+  - libgomp=9.3.0
+  - libsodium=1.0.18
+  - libstdcxx-ng=9.3.0
+  - markupsafe=1.1.1
+  - mistune=0.8.4
+  - nbclient=0.5.1
+  - nbconvert=6.0.7
+  - nbformat=5.0.8
+  - ncurses=6.2
+  - nest-asyncio=1.4.1
+  - notebook=6.1.4
+  - openssl=1.1.1h
+  - packaging=20.4
+  - pandoc=2.11.0.2
+  - pandocfilters=1.4.2
+  - pexpect=4.8.0
+  - pickleshare=0.7.5
+  - pip=20.2.3
+  - prodigal=2.6.3
+  - prometheus_client=0.8.0
+  - prompt_toolkit=1.0.15
+  - ptyprocess=0.6.0
+  - pycparser=2.20
+  - pygments=2.7.1
+  - pyopenssl=19.1.0
+  - pyparsing=2.4.7
+  - pyrsistent=0.17.3
+  - pysocks=1.7.1
+  - python=3.7.8
+  - python-dateutil=2.8.1
+  - python_abi=3.7
+  - pyzmq=19.0.2
+  - readline=8.0
+  - requests=2.24.0
+  - send2trash=1.5.0
+  - setuptools=49.6.0
+  - simplegeneric=0.8.1
+  - six=1.15.0
+  - sqlite=3.33.0
+  - terminado=0.9.1
+  - testpath=0.4.4
+  - tk=8.6.10
+  - tornado=6.0.4
+  - traitlets=5.0.5
+  - urllib3=1.25.10
+  - wcwidth=0.2.5
+  - webencodings=0.5.1
+  - wheel=0.35.1
+  - xz=5.2.5
+  - zeromq=4.3.3
+  - zipp=3.3.1
+  - zlib=1.2.11
   - pip:
     - alabaster==0.7.12
-    - attrs==20.2.0
+    - appdirs==1.4.4
     - babel==2.8.0
     - bioprov==0.1.7
     - biopython==1.78
-    - chardet==3.0.4
+    - black==20.8b1
+    - click==7.1.2
     - coolname==1.1.0
     - coverage==5.3
     - coveralls==2.1.2
     - dataclasses==0.6
-    - decorator==4.4.2
     - docopt==0.6.2
     - docutils==0.16
-    - idna==2.10
     - imagesize==1.2.0
-    - importlib-metadata==2.0.0
     - iniconfig==1.1.1
     - isodate==0.6.0
-    - jinja2==2.11.2
     - lxml==4.5.2
     - markdown-it-py==0.5.5
-    - markupsafe==1.1.1
+    - mypy-extensions==0.4.3
     - myst-parser==0.12.10
     - networkx==2.5
     - numpy==1.19.2
-    - packaging==20.4
     - pandas==1.1.3
+    - pathspec==0.8.0
     - pluggy==0.13.1
     - prov==1.5.3
     - py==1.9.0
     - pydot==1.4.1
-    - pygments==2.7.1
-    - pyparsing==2.4.7
     - pytest==6.1.1
     - pytest-cov==2.10.1
-    - python-dateutil==2.8.1
     - pytz==2020.1
     - pyyaml==5.3.1
     - rdflib==5.0.0
-    - requests==2.24.0
-    - six==1.15.0
+    - regex==2020.10.15
     - snowballstemmer==2.0.0
     - sphinx==3.2.1
     - sphinx-rtd-theme==0.5.0
@@ -74,6 +139,5 @@ dependencies:
     - sphinxcontrib-serializinghtml==1.1.4
     - toml==0.10.1
     - tqdm==4.50.2
-    - urllib3==1.25.10
-    - zipp==3.3.1
-
+    - typed-ast==1.4.1
+    - typing-extensions==3.7.4.3


### PR DESCRIPTION
Changes made:

* Added jupyter-lab and black to the conda environment, though they aren't direct code dependencies, they are necessary for development (Code styling and tutorials)
* Made a platform-agnostic conda environment.yml, this is done by omitting the builds when exporting (`conda env export -f environment.yml --no-builds`). Which should be the way to go from now on.
* Added notes on the contribution guidelines on how to install and update the development environment.