### PR TITLE
Setting input argument as required for Workflow class

### DIFF
--- a/bioprov/src/workflow.py
+++ b/bioprov/src/workflow.py
@@ -130,6 +130,7 @@ class Workflow:
             If a file, must contain column '{self.index_col}' for sample ID and '{self.file_columns}' for files.\
             See program help for information.
             """,
+            required=True,
         )
         parser.add_argument(
             "-c",


### PR DESCRIPTION
This fixes the error when calling a workflow defined with the Workflow class with no arguments.

Closes #10. 