### PR TITLE
Add assertion to PresetProgram tests

### DIFF
--- a/bioprov/tests/test_bioprov_programs.py
+++ b/bioprov/tests/test_bioprov_programs.py
@@ -31,8 +31,12 @@ def test_prokka():
     :return:
     """
     s = Sample("Synechococcus", files={"assembly": synechococcus_genome})
-    _ = prokka(s)
-    pass
+    prokka_program = prokka(s)
+    prokka_params = list(prokka_program.serializer()["params"].keys())
+
+    expected_params = ["--prefix", "--outdir", "--cpus", ""]
+
+    assert prokka_params == expected_params
 
 
 def test_kaiju():
@@ -41,7 +45,12 @@ def test_kaiju():
     :return:
     """
     s = Sample("Synechococcus", files={"R1": synechococcus_genome, "R2": "r2.fastq"})
-    _ = kaiju(s)
+    kaiju_program = kaiju(s)
+    kaiju_params = list(kaiju_program.serializer()["params"].keys())
+
+    expected_params = ["-t", "-i", "-j", "-f", "-z", "-o"]
+
+    assert kaiju_params == expected_params
 
 
 def test_kaiju2table():
@@ -50,4 +59,9 @@ def test_kaiju2table():
     :return:
     """
     s = Sample("Synechococcus", files={"kaiju_output": synechococcus_genome})
-    _ = kaiju2table(s)
+    kaiju2tab_program = kaiju2table(s)
+    kaiju2tab_params = list(kaiju2tab_program.serializer()["params"].keys())
+
+    expected_params = ["-o", "-t", "-n", "-r"]
+
+    assert kaiju2tab_params == expected_params


### PR DESCRIPTION
* Changes made:
   * Makes the presets be tested based on their serialized version, specifically, testing if the params are equal to what is expected. This improves on the previous testing done, where it was basically tested only if these classes could be initiated.

I initially tried to test against the whole serialized dictionary, but that wasn't viable, as there are many machine-specific paths.
