### PR TITLE
Update environment and W3C tutorial

### DIFF
--- a/docs/tutorials/w3c-prov.ipynb
+++ b/docs/tutorials/w3c-prov.ipynb
@@ -21,20 +21,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Project 'hopeful-deer' with 2 samples."
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import bioprov as bp\n",
     "from bioprov.data import picocyano_dataset\n",
@@ -51,39 +40,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "PosixPath('/Users/vini/anaconda3/envs/bioprov/lib/python3.7/site-packages/bioprov/data/datasets/picocyano.csv')"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "picocyano_dataset"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sample-id,assembly,taxon\n",
-      "GCF_000010065.1_ASM1006v1,bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna,Synechococcus elongatus PCC 6301\n",
-      "GCF_000007925.1_ASM792v1,bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic.fna,Prochlorococcus marinus CCMP1375\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Take a peek at the file\n",
     "!cat ../../bioprov/data/datasets/picocyano.csv"
@@ -100,20 +68,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Project 'coral-mackerel' with 2 samples."
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -138,21 +95,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'GCF_000010065.1_ASM1006v1': Sample GCF_000010065.1_ASM1006v1 with 1 file(s)., 'GCF_000007925.1_ASM792v1': Sample GCF_000007925.1_ASM792v1 with 1 file(s).} \n",
-      "\n",
-      "{'assembly': /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna} \n",
-      "\n",
-      "{'assembly': '../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna', 'taxon': 'Synechococcus elongatus PCC 6301'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj = bp.from_df(df, file_cols=[\"assembly\",])\n",
     "\n",
@@ -171,20 +116,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Project 'W3C-PROV-tutorial.json' with 2 samples."
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj = bp.read_csv(picocyano_dataset, file_cols=[\"assembly\",])\n",
     "\n",
@@ -206,20 +140,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Project 'W3C-PROV-tutorial.json' with 2 samples."
-      ]
-     },
-     "execution_count": 21,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = pd.read_csv(picocyano_dataset)\n",
     "df['assembly'] = \"../../\" + df[\"assembly\"]\n",
@@ -235,63 +158,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'path': PosixPath('/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna'),\n",
-       " 'name': 'GCF_000010065.1_ASM1006v1_genomic',\n",
-       " 'basename': 'GCF_000010065.1_ASM1006v1_genomic.fna',\n",
-       " 'directory': PosixPath('/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes'),\n",
-       " 'extension': '.fna',\n",
-       " 'tag': 'assembly',\n",
-       " 'attributes': {},\n",
-       " '_exists': True,\n",
-       " '_size': '2.6 MB',\n",
-       " 'raw_size': 2730026,\n",
-       " '_sha1': 'f8658496b343257690f828ec14226644dc9e9ca2',\n",
-       " '_entity': None,\n",
-       " 'format': 'fasta',\n",
-       " 'records': {'NC_006576.1': SeqRecord(seq=Seq('ATTTAAATCACTGGCATCAGCATTCGCAATATCATTGAGGTCAACAATACTTTC...GGC'), id='NC_006576.1', name='NC_006576.1', description='NC_006576.1 Synechococcus elongatus PCC 6301 DNA, complete genome', dbxrefs=[])},\n",
-       " '_generator': <Bio.SeqIO.FastaIO.FastaIterator at 0x7ff342d6ecd0>,\n",
-       " '_seqstats': SeqStats(number_seqs=1, total_bps=2696255, mean_bp=2696255.0, min_bp=2696255, max_bp=2696255, N50=2696255, GC=0.55484),\n",
-       " '_parser': 'seq',\n",
-       " 'number_seqs': 1,\n",
-       " 'total_bps': 2696255,\n",
-       " 'mean_bp': 2696255.0,\n",
-       " 'min_bp': 2696255,\n",
-       " 'max_bp': 2696255,\n",
-       " 'N50': 2696255,\n",
-       " 'GC': 0.55484}"
-      ]
-     },
-     "execution_count": 22,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj[\"GCF_000010065.1_ASM1006v1\"].files['assembly'].__dict__"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "SeqStats(number_seqs=1, total_bps=2696255, mean_bp=2696255.0, min_bp=2696255, max_bp=2696255, N50=2696255, GC=0.55484)"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj[\"GCF_000010065.1_ASM1006v1\"].files['assembly'].seqstats"
    ]
@@ -307,30 +185,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Running program 'prodigal' for sample GCF_000010065.1_ASM1006v1.\n",
-      "Command is:\n",
-      "/Users/vini/anaconda3/envs/bioprov/bin/prodigal \\ \n",
-      "\t-i /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna \\ \n",
-      "\t-a /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_proteins.faa \\ \n",
-      "\t-d /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_genes.fna \\ \n",
-      "\t-s /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_scores.cds \n",
-      "Running program 'prodigal' for sample GCF_000007925.1_ASM792v1.\n",
-      "Command is:\n",
-      "/Users/vini/anaconda3/envs/bioprov/bin/prodigal \\ \n",
-      "\t-i /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic.fna \\ \n",
-      "\t-a /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_proteins.faa \\ \n",
-      "\t-d /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_genes.fna \\ \n",
-      "\t-s /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_scores.cds \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from bioprov.programs import prodigal\n",
     "\n",
@@ -349,49 +206,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mInit signature:\u001b[0m\n",
-       "\u001b[0mbp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPresetProgram\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mparams\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0msample\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0minput_files\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0moutput_files\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mpreffix_tag\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-       "\u001b[0;31mDocstring:\u001b[0m     \n",
-       "Class for holding a preset program and related functions.\n",
-       "\n",
-       "A WorkflowStep instance inherits from Program and consists of an instance\n",
-       "of Program with an associated instance of Sample or Project.\n",
-       "\u001b[0;31mInit docstring:\u001b[0m\n",
-       ":param name: Instance of bioprov.Program\n",
-       ":param params: Dictionary of parameters.\n",
-       ":param sample: An instance of Sample or Project.\n",
-       ":param input_files: A dictionary consisting of Parameter keys as keys and a File.tag\n",
-       "                    as value, where File.tag is a string that must be a key in\n",
-       "                    self.sample.files with a corresponding existing file.\n",
-       ":param output_files: A dictionary consisting of Parameter keys as keys and a tuple\n",
-       "                     consisting of (File.tag, suffix) as value.\n",
-       "                     File.tag will become a key in self.sample.files and the its value\n",
-       "                     will be the sample_name + suffix.\n",
-       ":param preffix_tag: A value in the input_files argument, which corresponds\n",
-       "                    to a key in self.sample.files. All file names of output\n",
-       "                    files will be stemmed from this file, hence 'preffix'.\n",
-       "\u001b[0;31mFile:\u001b[0m           ~/anaconda3/envs/bioprov/lib/python3.7/site-packages/bioprov/src/main.py\n",
-       "\u001b[0;31mType:\u001b[0m           type\n",
-       "\u001b[0;31mSubclasses:\u001b[0m     \n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bp.PresetProgram?"
    ]
@@ -407,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -423,18 +240,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Project 'W3C-PROV-tutorial.json' with 2 samples. \n",
-      "\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(prov.project, \"\\n\")"
    ]
@@ -452,101 +260,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PROV-N \n",
-      "\n",
-      " document\n",
-      "  prefix project <Project 'W3C-PROV-tutorial.json' with 2 samples.>\n",
-      "  prefix users <Users associated with BioProv Project 'W3C-PROV-tutorial.json'>\n",
-      "  prefix samples <Samples associated with bioprov Project 'W3C-PROV-tutorial.json'>\n",
-      "  prefix GCF_000010065.1_ASM1006v1.programs <Programs associated with Sample GCF_000010065.1_ASM1006v1>\n",
-      "  prefix envs <Environments associated with User 'vini'>\n",
-      "  prefix GCF_000007925.1_ASM792v1.programs <Programs associated with Sample GCF_000007925.1_ASM792v1>\n",
-      "  \n",
-      "  entity(project:Project 'W3C-PROV-tutorial.json' with 2 samples.)\n",
-      "  wasDerivedFrom(samples:GCF_000010065.1_ASM1006v1, project:Project 'W3C-PROV-tutorial.json' with 2 samples., -, -, -)\n",
-      "  wasDerivedFrom(GCF_000010065.1_ASM1006v1.programs:prodigal, envs:Environment_caafe21a8b87100b49a042b205b378e1a106dc7a, -, -, -)\n",
-      "  wasDerivedFrom(samples:GCF_000007925.1_ASM792v1, project:Project 'W3C-PROV-tutorial.json' with 2 samples., -, -, -)\n",
-      "  wasDerivedFrom(GCF_000007925.1_ASM792v1.programs:prodigal, envs:Environment_caafe21a8b87100b49a042b205b378e1a106dc7a, -, -, -)\n",
-      "  bundle users:vini\n",
-      "    default <vini>\n",
-      "    prefix envs <Environments associated with User 'vini'>\n",
-      "    prefix users <Users associated with BioProv Project 'W3C-PROV-tutorial.json'>\n",
-      "    \n",
-      "    agent(users:vini)\n",
-      "    entity(envs:Environment_caafe21a8b87100b49a042b205b378e1a106dc7a)\n",
-      "    wasAttributedTo(envs:Environment_caafe21a8b87100b49a042b205b378e1a106dc7a, users:vini)\n",
-      "  endBundle\n",
-      "  bundle samples:GCF_000010065.1_ASM1006v1\n",
-      "    default <GCF_000010065.1_ASM1006v1>\n",
-      "    prefix GCF_000010065.1_ASM1006v1.files <Files associated with Sample GCF_000010065.1_ASM1006v1>\n",
-      "    prefix GCF_000010065.1_ASM1006v1_genomic </Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna>\n",
-      "    prefix samples <Samples associated with bioprov Project 'W3C-PROV-tutorial.json'>\n",
-      "    prefix GCF_000010065.1_ASM1006v1_genomic_proteins </Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_proteins.faa>\n",
-      "    prefix GCF_000010065.1_ASM1006v1_genomic_genes </Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_genes.fna>\n",
-      "    prefix GCF_000010065.1_ASM1006v1_genomic_scores </Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_scores.cds>\n",
-      "    prefix GCF_000010065.1_ASM1006v1.programs <Programs associated with Sample GCF_000010065.1_ASM1006v1>\n",
-      "    \n",
-      "    entity(samples:GCF_000010065.1_ASM1006v1)\n",
-      "    entity(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic)\n",
-      "    wasDerivedFrom(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic, samples:GCF_000010065.1_ASM1006v1, -, -, -)\n",
-      "    entity(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_proteins)\n",
-      "    wasDerivedFrom(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_proteins, samples:GCF_000010065.1_ASM1006v1, -, -, -)\n",
-      "    entity(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_genes)\n",
-      "    wasDerivedFrom(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_genes, samples:GCF_000010065.1_ASM1006v1, -, -, -)\n",
-      "    entity(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_scores)\n",
-      "    wasDerivedFrom(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_scores, samples:GCF_000010065.1_ASM1006v1, -, -, -)\n",
-      "    activity(GCF_000010065.1_ASM1006v1.programs:prodigal, 2020-10-23T16:30:20, 2020-10-23T16:30:27)\n",
-      "    used(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic, GCF_000010065.1_ASM1006v1.programs:prodigal, -)\n",
-      "    wasGeneratedBy(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_proteins, GCF_000010065.1_ASM1006v1.programs:prodigal, -)\n",
-      "    wasGeneratedBy(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_genes, GCF_000010065.1_ASM1006v1.programs:prodigal, -)\n",
-      "    wasGeneratedBy(GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_scores, GCF_000010065.1_ASM1006v1.programs:prodigal, -)\n",
-      "  endBundle\n",
-      "  bundle samples:GCF_000007925.1_ASM792v1\n",
-      "    default <GCF_000007925.1_ASM792v1>\n",
-      "    prefix GCF_000007925.1_ASM792v1.files <Files associated with Sample GCF_000007925.1_ASM792v1>\n",
-      "    prefix GCF_000007925.1_ASM792v1_genomic </Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic.fna>\n",
-      "    prefix samples <Samples associated with bioprov Project 'W3C-PROV-tutorial.json'>\n",
-      "    prefix GCF_000007925.1_ASM792v1_genomic_proteins </Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_proteins.faa>\n",
-      "    prefix GCF_000007925.1_ASM792v1_genomic_genes </Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_genes.fna>\n",
-      "    prefix GCF_000007925.1_ASM792v1_genomic_scores </Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_scores.cds>\n",
-      "    prefix GCF_000007925.1_ASM792v1.programs <Programs associated with Sample GCF_000007925.1_ASM792v1>\n",
-      "    \n",
-      "    entity(samples:GCF_000007925.1_ASM792v1)\n",
-      "    entity(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic)\n",
-      "    wasDerivedFrom(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic, samples:GCF_000007925.1_ASM792v1, -, -, -)\n",
-      "    entity(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_proteins)\n",
-      "    wasDerivedFrom(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_proteins, samples:GCF_000007925.1_ASM792v1, -, -, -)\n",
-      "    entity(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_genes)\n",
-      "    wasDerivedFrom(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_genes, samples:GCF_000007925.1_ASM792v1, -, -, -)\n",
-      "    entity(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_scores)\n",
-      "    wasDerivedFrom(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_scores, samples:GCF_000007925.1_ASM792v1, -, -, -)\n",
-      "    activity(GCF_000007925.1_ASM792v1.programs:prodigal, 2020-10-23T16:30:27, 2020-10-23T16:30:32)\n",
-      "    used(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic, GCF_000007925.1_ASM792v1.programs:prodigal, -)\n",
-      "    wasGeneratedBy(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_proteins, GCF_000007925.1_ASM792v1.programs:prodigal, -)\n",
-      "    wasGeneratedBy(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_genes, GCF_000007925.1_ASM792v1.programs:prodigal, -)\n",
-      "    wasGeneratedBy(GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_scores, GCF_000007925.1_ASM792v1.programs:prodigal, -)\n",
-      "  endBundle\n",
-      "endDocument\n",
-      "PROV-JSON \n",
-      "\n",
-      " {\"prefix\": {\"project\": \"Project 'W3C-PROV-tutorial.json' with 2 samples.\", \"users\": \"Users associated with BioProv Project 'W3C-PROV-tutorial.json'\", \"samples\": \"Samples associated with bioprov Project 'W3C-PROV-tutorial.json'\", \"GCF_000010065.1_ASM1006v1.programs\": \"Programs associated with Sample GCF_000010065.1_ASM1006v1\", \"envs\": \"Environments associated with User 'vini'\", \"GCF_000007925.1_ASM792v1.programs\": \"Programs associated with Sample GCF_000007925.1_ASM792v1\"}, \"entity\": {\"project:Project 'W3C-PROV-tutorial.json' with 2 samples.\": {}}, \"wasDerivedFrom\": {\"_:id1\": {\"prov:generatedEntity\": \"samples:GCF_000010065.1_ASM1006v1\", \"prov:usedEntity\": \"project:Project 'W3C-PROV-tutorial.json' with 2 samples.\"}, \"_:id2\": {\"prov:generatedEntity\": \"GCF_000010065.1_ASM1006v1.programs:prodigal\", \"prov:usedEntity\": \"envs:Environment_caafe21a8b87100b49a042b205b378e1a106dc7a\"}, \"_:id3\": {\"prov:generatedEntity\": \"samples:GCF_000007925.1_ASM792v1\", \"prov:usedEntity\": \"project:Project 'W3C-PROV-tutorial.json' with 2 samples.\"}, \"_:id4\": {\"prov:generatedEntity\": \"GCF_000007925.1_ASM792v1.programs:prodigal\", \"prov:usedEntity\": \"envs:Environment_caafe21a8b87100b49a042b205b378e1a106dc7a\"}}, \"bundle\": {\"users:vini\": {\"prefix\": {\"envs\": \"Environments associated with User 'vini'\", \"users\": \"Users associated with BioProv Project 'W3C-PROV-tutorial.json'\", \"default\": \"vini\"}, \"agent\": {\"users:vini\": {}}, \"entity\": {\"envs:Environment_caafe21a8b87100b49a042b205b378e1a106dc7a\": {}}, \"wasAttributedTo\": {\"_:id1\": {\"prov:entity\": \"envs:Environment_caafe21a8b87100b49a042b205b378e1a106dc7a\", \"prov:agent\": \"users:vini\"}}}, \"samples:GCF_000010065.1_ASM1006v1\": {\"prefix\": {\"GCF_000010065.1_ASM1006v1.files\": \"Files associated with Sample GCF_000010065.1_ASM1006v1\", \"GCF_000010065.1_ASM1006v1_genomic\": \"/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna\", \"samples\": \"Samples associated with bioprov Project 'W3C-PROV-tutorial.json'\", \"GCF_000010065.1_ASM1006v1_genomic_proteins\": \"/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_proteins.faa\", \"GCF_000010065.1_ASM1006v1_genomic_genes\": \"/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_genes.fna\", \"GCF_000010065.1_ASM1006v1_genomic_scores\": \"/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_scores.cds\", \"GCF_000010065.1_ASM1006v1.programs\": \"Programs associated with Sample GCF_000010065.1_ASM1006v1\", \"default\": \"GCF_000010065.1_ASM1006v1\"}, \"entity\": {\"samples:GCF_000010065.1_ASM1006v1\": {}, \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic\": {}, \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_proteins\": {}, \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_genes\": {}, \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_scores\": {}}, \"wasDerivedFrom\": {\"_:id1\": {\"prov:generatedEntity\": \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic\", \"prov:usedEntity\": \"samples:GCF_000010065.1_ASM1006v1\"}, \"_:id2\": {\"prov:generatedEntity\": \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_proteins\", \"prov:usedEntity\": \"samples:GCF_000010065.1_ASM1006v1\"}, \"_:id3\": {\"prov:generatedEntity\": \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_genes\", \"prov:usedEntity\": \"samples:GCF_000010065.1_ASM1006v1\"}, \"_:id4\": {\"prov:generatedEntity\": \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_scores\", \"prov:usedEntity\": \"samples:GCF_000010065.1_ASM1006v1\"}}, \"activity\": {\"GCF_000010065.1_ASM1006v1.programs:prodigal\": {\"prov:startTime\": \"2020-10-23T16:30:20\", \"prov:endTime\": \"2020-10-23T16:30:27\"}}, \"used\": {\"_:id5\": {\"prov:activity\": \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic\", \"prov:entity\": \"GCF_000010065.1_ASM1006v1.programs:prodigal\"}}, \"wasGeneratedBy\": {\"_:id6\": {\"prov:entity\": \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_proteins\", \"prov:activity\": \"GCF_000010065.1_ASM1006v1.programs:prodigal\"}, \"_:id7\": {\"prov:entity\": \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_genes\", \"prov:activity\": \"GCF_000010065.1_ASM1006v1.programs:prodigal\"}, \"_:id8\": {\"prov:entity\": \"GCF_000010065.1_ASM1006v1.files:GCF_000010065.1_ASM1006v1_genomic_scores\", \"prov:activity\": \"GCF_000010065.1_ASM1006v1.programs:prodigal\"}}}, \"samples:GCF_000007925.1_ASM792v1\": {\"prefix\": {\"GCF_000007925.1_ASM792v1.files\": \"Files associated with Sample GCF_000007925.1_ASM792v1\", \"GCF_000007925.1_ASM792v1_genomic\": \"/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic.fna\", \"samples\": \"Samples associated with bioprov Project 'W3C-PROV-tutorial.json'\", \"GCF_000007925.1_ASM792v1_genomic_proteins\": \"/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_proteins.faa\", \"GCF_000007925.1_ASM792v1_genomic_genes\": \"/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_genes.fna\", \"GCF_000007925.1_ASM792v1_genomic_scores\": \"/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_scores.cds\", \"GCF_000007925.1_ASM792v1.programs\": \"Programs associated with Sample GCF_000007925.1_ASM792v1\", \"default\": \"GCF_000007925.1_ASM792v1\"}, \"entity\": {\"samples:GCF_000007925.1_ASM792v1\": {}, \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic\": {}, \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_proteins\": {}, \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_genes\": {}, \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_scores\": {}}, \"wasDerivedFrom\": {\"_:id1\": {\"prov:generatedEntity\": \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic\", \"prov:usedEntity\": \"samples:GCF_000007925.1_ASM792v1\"}, \"_:id2\": {\"prov:generatedEntity\": \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_proteins\", \"prov:usedEntity\": \"samples:GCF_000007925.1_ASM792v1\"}, \"_:id3\": {\"prov:generatedEntity\": \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_genes\", \"prov:usedEntity\": \"samples:GCF_000007925.1_ASM792v1\"}, \"_:id4\": {\"prov:generatedEntity\": \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_scores\", \"prov:usedEntity\": \"samples:GCF_000007925.1_ASM792v1\"}}, \"activity\": {\"GCF_000007925.1_ASM792v1.programs:prodigal\": {\"prov:startTime\": \"2020-10-23T16:30:27\", \"prov:endTime\": \"2020-10-23T16:30:32\"}}, \"used\": {\"_:id5\": {\"prov:activity\": \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic\", \"prov:entity\": \"GCF_000007925.1_ASM792v1.programs:prodigal\"}}, \"wasGeneratedBy\": {\"_:id6\": {\"prov:entity\": \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_proteins\", \"prov:activity\": \"GCF_000007925.1_ASM792v1.programs:prodigal\"}, \"_:id7\": {\"prov:entity\": \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_genes\", \"prov:activity\": \"GCF_000007925.1_ASM792v1.programs:prodigal\"}, \"_:id8\": {\"prov:entity\": \"GCF_000007925.1_ASM792v1.files:GCF_000007925.1_ASM792v1_genomic_scores\", \"prov:activity\": \"GCF_000007925.1_ASM792v1.programs:prodigal\"}}}}}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from prov.dot import prov_to_dot\n",
-    "\n",
     "print(\"PROV-N\", \"\\n\\n\", prov.ProvDocument.get_provn())\n",
     "print(\"PROV-JSON\", \"\\n\\n\", prov.ProvDocument.serialize())\n",
-    "dot = prov_to_dot(prov.ProvDocument)\n",
-    "dot.write_png(\"W3C-PROV-tutorial.png\")"
+    "dot = prov.dot\n",
+    "dot.write_png(\"W3C-PROV-tutorial.png\")\n",
+    "# You can also save the provenance graph in DOT language\n",
+    "dot.write_raw(\"W3C-PROV-tutorial.gv\")"
    ]
   },
   {
@@ -574,7 +297,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:bioprov]",
+   "display_name": "Python [conda env:bioprov] *",
    "language": "python",
    "name": "conda-env-bioprov-py"
   },
@@ -588,7 +311,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/environment.yml
+++ b/environment.yml
@@ -46,6 +46,7 @@ dependencies:
   - libstdcxx-ng=9.3.0
   - markupsafe=1.1.1
   - mistune=0.8.4
+  - nb_conda_kernels=2.3.0
   - nbclient=0.5.1
   - nbconvert=6.0.7
   - nbformat=5.0.8
@@ -97,7 +98,7 @@ dependencies:
     - alabaster==0.7.12
     - appdirs==1.4.4
     - babel==2.8.0
-    - bioprov==0.1.7
+    - bioprov==0.1.13
     - biopython==1.78
     - black==20.8b1
     - click==7.1.2
@@ -137,6 +138,7 @@ dependencies:
     - sphinxcontrib-jsmath==1.0.1
     - sphinxcontrib-qthelp==1.0.3
     - sphinxcontrib-serializinghtml==1.1.4
+    - tinydb==4.2.0
     - toml==0.10.1
     - tqdm==4.50.2
     - typed-ast==1.4.1


### PR DESCRIPTION
Minor changes made:
 * Closes #20; Updates environment.yml with new dependencies.
 * Updates W3C-Prov Tutorial to use only native functions, as discussed in https://github.com/vinisalazar/BioProv/pull/19#discussion_r511196338

