### PR TITLE
Add MAFFT PresetProgram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     * .write_paths_to_file, .copy_files_to_dir(), .link_files_to_dir() [ ]
 * Add logger calls when saving to JSON and uploading to PyPI [ ]
 * Add Muscle PresetProgram [x]
+* Add MAFFT PresetProgram [x]
 
 ### v0.1.19
 * Debug API endpoint (#23) [x]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### BioProv - W3C-PROV provenance documents for bioinformatics
 
 
-Package | [![License](https://img.shields.io/github/license/vinisalazar/bioprov)](https://img.shields.io/github/license/vinisalazar/bioprov) | [![PyPI Version](https://img.shields.io/pypi/v/bioprov)](https://pypi.org/project/bioprov/) | [![Requirements Status](https://requires.io/github/vinisalazar/BioProv/requirements.svg?branch=master)](https://requires.io/github/vinisalazar/BioProv/requirements/?branch=master)
+Package | [![License](https://img.shields.io/github/license/vinisalazar/bioprov)](https://github.com/vinisalazar/BioProv/blob/master/LICENSE) | [![PyPI Version](https://img.shields.io/pypi/v/bioprov)](https://pypi.org/project/bioprov/) | [![Requirements Status](https://requires.io/github/vinisalazar/BioProv/requirements.svg?branch=master)](https://requires.io/github/vinisalazar/BioProv/requirements/?branch=master)
 ---------------|--|--|--
 Tests | [![Build Status](https://travis-ci.org/vinisalazar/BioProv.svg?branch=master)](https://travis-ci.org/vinisalazar/BioProv) |  [![tests](https://github.com/vinisalazar/bioprov/workflows/tests/badge.svg?branch=master)](https://github.com/vinisalazar/bioprov/actions?query=workflow%3Atests) | [![Coverage Status](https://coveralls.io/repos/github/vinisalazar/BioProv/badge.svg?branch=master&service=github)](https://coveralls.io/github/vinisalazar/BioProv?branch=master&service=github)
 Code | [![Code style](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black) | [![lint](https://github.com/vinisalazar/BioProv/workflows/lint/badge.svg?branch=master)](https://github.com/vinisalazar/BioProv/actions?query=workflow%3Alint)

--- a/bioprov/programs/__init__.py
+++ b/bioprov/programs/__init__.py
@@ -11,6 +11,7 @@ from .programs import (
     blastn,
     blastp,
     muscle,
+    mafft,
     prokka,
     kaiju,
     kaiju2table,

--- a/bioprov/programs/programs.py
+++ b/bioprov/programs/programs.py
@@ -152,6 +152,23 @@ def muscle(sample, input_tag="input", msf=False):
     return _muscle
 
 
+def mafft(sample, input_tag="input"):
+    """
+    :param sample: Instance of BioProv.Sample.
+    :param input_tag: Instance of BioProv.Sample.
+    :return: Instance of PresetProgram containing Prodigal.
+    """
+    _mafft = PresetProgram(
+        name="mafft",
+        sample=sample,
+        input_files={"": input_tag},
+        output_files={">": ("aligned", "_aligned.afa")},
+        preffix_tag=input_tag,
+    )
+
+    return _mafft
+
+
 def prokka_():
     """
     :return: Instance of PresetProgram containing Prokka.

--- a/bioprov/programs/programs.py
+++ b/bioprov/programs/programs.py
@@ -154,9 +154,10 @@ def muscle(sample, input_tag="input", msf=False):
 
 def mafft(sample, input_tag="input"):
     """
-    :param sample: Instance of BioProv.Sample.
-    :param input_tag: Instance of BioProv.Sample.
-    :return: Instance of PresetProgram containing Prodigal.
+    :param Sample sample: Instance of BioProv.Sample.
+    :param str input_tag:  A tag for the input fasta file.
+    :return: Instance of PresetProgram containing MAFFT.
+    :rtype: BioProv.PresetProgram.
     """
     _mafft = PresetProgram(
         name="mafft",

--- a/bioprov/tests/test_bioprov_programs.py
+++ b/bioprov/tests/test_bioprov_programs.py
@@ -15,6 +15,7 @@ from bioprov.programs import (
     blastn,
     blastp,
     muscle,
+    mafft,
     diamond,
     kaiju,
     kaiju2table,
@@ -88,6 +89,18 @@ def test_muscle():
     expected = ["-in", "-out", "-msf"]
 
     assert list(muscle_params.keys()) == expected
+
+
+def test_mafft():
+
+    s = Sample("Synechococcus", files={"input": synechococcus_genome})
+
+    mafft_prog = mafft(s)
+    mafft_params = mafft_prog.serializer()["params"]
+
+    expected = ["", ">"]
+
+    assert list(mafft_params.keys()) == expected
 
 
 def test_prodigal():


### PR DESCRIPTION
Changes made:
- Add PresetProgram for MAFFT + test
- Update CHANGELOG with MAFFT
- Fix license badge on README (Just so it links to the license source file)

This is my workaround for programs that need to be declared like `program input > output`, it looks a bit weird, if you can think of a better alternative, feel free to point out. Just so you know I manually tested running the preset and it works.