### PR TITLE
ci: Improve create-release action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -13,6 +13,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - run: |
+          lastversion=$(git describe --tags)
+          awk /"$lastversion"'/{flag=1; next} /###/{flag=0} flag' CHANGELOG.md >> release.md
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1
@@ -21,9 +24,6 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: Release ${{ github.ref }}
-          body: |
-            Changes in this Release
-            - First Change
-            - Second Change
+          body_path: release.md
           draft: false
           prerelease: false


### PR DESCRIPTION
Changes made:
* Improve create-release action.

Something that bothered me seeing the releases for your repo was that it usually contained the default text, requiring you to manually go and edit the release so it contains something meaningful, which is a bit tedious.

[See the current release (v0.1.22) for reference, which I believe you forgot to edit hahah.](https://github.com/vinisalazar/BioProv/releases/tag/v0.1.22)

Now I added some bash magic to the action so it extracts the info for the latest release through the changelog file. Basically an awk extraction that gets the text between the lastest and the second-to-latest tag.

I've tested it and it's working as intended. As long as you keep the same format for the changelog, should be all good. Just so you know how it would look, I used your changelog on a private repo and the action created this for v0.1.4:
![image](https://user-images.githubusercontent.com/43506501/105244522-6f226080-5b4f-11eb-8eb3-e9c79f3c4fa9.png)

