### PR TITLE
docs: Add tutorial for PresetPrograms & Workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 bioprov/db.json
 bioprov/provstore_api.txt
 **/*.log
+docs/tutorials/*txt
+docs/tutorials/*csv
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -136,3 +138,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# VSCode
+.vscode

--- a/docs/tutorials/introduction.ipynb
+++ b/docs/tutorials/introduction.ipynb
@@ -9,6 +9,7 @@
     "### Tutorial index\n",
     "* <a href=\"./introduction.ipynb\">Introduction to BioProv</a>\n",
     "* <a href=\"./w3c-prov.ipynb\">W3C-PROV projects</a>\n",
+    "* <a href=\"./workflows_and_presets.ipynb\">Presets and Workflows</a>\n",
     "\n",
     "## Introduction to BioProv\n",
     "\n",
@@ -331,7 +332,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:bioprov]",
+   "display_name": "Python [conda env:bioprov] *",
    "language": "python",
    "name": "conda-env-bioprov-py"
   },
@@ -345,7 +346,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/presets_and_workflows.ipynb
+++ b/docs/tutorials/presets_and_workflows.ipynb
@@ -1,0 +1,392 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Presets and Workflows"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Tutorial index\n",
+    "* <a href=\"./introduction.ipynb\">Introduction to BioProv</a>\n",
+    "* <a href=\"./w3c-prov.ipynb\">W3C-PROV projects</a>\n",
+    "* <a href=\"./workflows_and_presets.ipynb\">Presets and Workflows</a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this tutorial, we're gonna take a look at how to build preset programs and workflows in order to accelerate the development of provenance-aware pipelines.\n",
+    "\n",
+    "This will be done using the PresetProgram and Workflow classes made available by BioProv."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Preset programs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As discussed before, manually creating programs is something that BioProv supports and encourages. But it might become a too repetitive if you find yourself using the same command structure frequently, therefore we provide the class PresetProgram, which facilitates creation of programs using a single object and makes it very easy to generalize the same program structure for running it in batches as well as building workflows with it."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "First off, it's good to know that BioProv already provides a series of different preset programs for common bioinformatics tasks, here is a list of them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import bioprov.programs\n",
+    "from inspect import getmembers, isfunction\n",
+    "\n",
+    "getmembers(bioprov.programs, isfunction)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you don't find the program you want in the list above, don't fret! We're gonna show you how to build your own next.\n",
+    "\n",
+    "First, let's read in the example data we've been using, as well as a blastdb for a subset of the [MegaRes database](https://megares.meglab.org/) made available through our data module."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import bioprov as bp\n",
+    "from bioprov import Sample\n",
+    "from bioprov.data import synechococcus_genome, megares_blastdb\n",
+    "\n",
+    "example_genome = Sample(\"Synechococcus\", files={\"assembly\": synechococcus_genome})"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And let's say, for demonstration purposes, that BioProv doesn't have a BlastN preset program but we still wish to align each of these genomes to the MegaRes BlastDB.\n",
+    "\n",
+    "To do that, we can go one of two paths: Manually creating the program object for BlastN in a script or, if we think this is a process we'll run many times over different days across various genomes, it might be wise to create a PresetProgram for it. We'll show you how to do the latter."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this you will need BlastN installed, which can be easily done through the [conda package manager](https://anaconda.org/bioconda/blast)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bioprov.src.main import Parameter, PresetProgram\n",
+    "\n",
+    "blastn = PresetProgram(\n",
+    "        name=\"blastn\",\n",
+    "        params=(\n",
+    "            Parameter(key=\"-db\", value=megares_blastdb),\n",
+    "            # outfmt 6 is the blastn tabular output format\n",
+    "            Parameter(key=\"-outfmt\", value=6),\n",
+    "        ),\n",
+    "        sample=example_genome,\n",
+    "        input_files={\"-query\": \"assembly\"},\n",
+    "        output_files={\"-out\": (\"megares_hits\", \"_megares_hits.txt\")}\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Okay, maybe that was a lot, let's break down what\n",
+    "PresetPrograms take in:\n",
+    "1. The program name, in this case `blastn`\n",
+    "\n",
+    "2. Some general parameters and corresponding values that will be used, defined through the `params` arguments.\n",
+    "\n",
+    "3. The input parameter, `-query` in this case, and the corresponding tag for the input sample, which we defined as 'assembly'.\n",
+    "\n",
+    "4. The output parameter, `-out` in this case, as well as a tag and a suffix for the output file. The tag will be added to the the sample's files and the output parameter value will correspond to the sample name + the suffix.\n",
+    "\n",
+    "We can also define the `extra_flags` argument, which is used to append extra command line parameters (flags or switches) to the end of the command string.\n",
+    "\n",
+    "Though less flexible than manually adding Files and Parameters as we saw for the Program class in the introductory tutorial, PresetPrograms support the general structure of most command line tools and help accelerate development as well as maintain the codebase shorter and easier to read."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Of course, we can then run this program the same way we would with any other one:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blastn.run()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then see the output file gets added to our Sample:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "example_genome.files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's turn this preset into a function that takes in only the sample, just so it's more reusable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def align_to_megares(assembly_sample):\n",
+    "    \n",
+    "    blastn = PresetProgram(\n",
+    "        name=\"blastn\",\n",
+    "        params=(\n",
+    "            Parameter(key=\"-db\", value=megares_blastdb),\n",
+    "            # outfmt 6 is the blastn tabular output format\n",
+    "            Parameter(key=\"-outfmt\", value=6),\n",
+    "        ),\n",
+    "        sample=assembly_sample,\n",
+    "        input_files={\"-query\": \"assembly\"},\n",
+    "        output_files={\"-out\": (\"megares_hits\", \"_megares_hits.txt\")}\n",
+    "    )\n",
+    "    \n",
+    "    return blastn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Workflows"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But then, let's suppose aligning to MegaRes is only the first step in a series of commands (or pipeline) we routinely run in our work.\n",
+    "\n",
+    "What we're describing here is a Workflow and BioProv provides a helper class to deal with this scenario."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's say the next step could be filtering the hits we obtained by their score and saving the filtered data. For this purpose, we could use an [AWK](https://en.wikipedia.org/wiki/Awk) command, so, let's build a PresetProgram for this task too! In this case, we'll use the output tag from the previous step as our input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def filter_high_score(alignment_sample):\n",
+    "    \n",
+    "    score_filter = PresetProgram(\n",
+    "        name=\"awk\",\n",
+    "        # Parameters can be ommitted!\n",
+    "        sample=alignment_sample,\n",
+    "        # Score greater or equal to 1000\n",
+    "        input_files={\"'$12>=1000'\": \"megares_hits\"},\n",
+    "        output_files={\">\": (\"high_score\", \"_high_score_hits.txt\")}\n",
+    "    )\n",
+    "    \n",
+    "    return score_filter"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Okay, let's start building a workflow using the two presets we've made.\n",
+    "\n",
+    "First thing we'll need is a dataset to use as input for the workflow, for that we'll use the `picocyano_dataset`, only altering the paths in the 'assembly' column to be the relative paths to their respective files. The workflow will run on all samples created from this dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bioprov.data import picocyano_dataset\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "df = pd.read_csv(picocyano_dataset)\n",
+    "\n",
+    "df[\"assembly\"] = \"../../\" + df[\"assembly\"]\n",
+    "\n",
+    "df.to_csv(path_or_buf=\"test_dataset.csv\", index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Then we can begin building the workflow itself, BioProv Workflow objects take in a lot of parameters (run `help(Workflow)` to see a list of them), the ones we'll be using today are:\n",
+    "\n",
+    "1. `name`: The name we'll choose for this workflow;\n",
+    "\n",
+    "2. `description`: A description for the workflow;\n",
+    "\n",
+    "3. `input`, `sep`: The input for the workflow. Since the input is a tabular data file, it's good to specify the column separator (it defaults to tabs);\n",
+    "\n",
+    "4. `input_type`: The type of input the workflow expects, it can be dataframe (a path to a tabular data file), a path to a directory of files or both.\n",
+    "\n",
+    "5. `index_col`, `file_columns`: These should be familiar to you if you've looked at the previous tutorials. It merely indicates what are the relevant portions of the dataframe to create the project with. \n",
+    "\n",
+    "6. `write_provn`: In case we want to write the PROVN document after running the workflow. Let's set it to true."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bioprov.src.workflow import Workflow, Step\n",
+    "\n",
+    "get_megares_hits = Workflow(\n",
+    "    name=\"Get best MegaRes hits\",\n",
+    "    description=\"Align nucleotide data to MegaRes with BLASTN and filters high-score (>=1000) hits.\",\n",
+    "    input='./test_dataset.csv',\n",
+    "    sep=\",\",\n",
+    "    input_type=\"dataframe\",\n",
+    "    index_col=\"sample-id\",\n",
+    "    file_columns=\"assembly\",\n",
+    "    write_provn=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Since this workflow isn't associated with any particular project, you can see BioProv generated a project using a random tag.\n",
+    "\n",
+    "Now let's add the steps to this workflow using the PresetProgram functions we built before. You might think it's strange we're setting the samples to None, but this is just so the function returns a PresetProgram instance, which the Workflow expects, the samples will be injected from the dataset we used as input for the workflow (so it won't be None in the end)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "steps = [\n",
+    "    Step(align_to_megares(None), default=True),\n",
+    "    Step(filter_high_score(None), default=True),\n",
+    "]\n",
+    "\n",
+    "for _step in steps:\n",
+    "        get_megares_hits.add_step(_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can then choose which steps we want to run using a list as input to the `run_steps` method. They will then run in the order they were added to the workflow."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "get_megares_hits.run_steps(['blastn', 'awk'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Wow, that was a lot of stuff! But, if you look into this tutorial's directory, you will see a list of outputs corresponding to each step of the workflow, which ran for each file in the input dataset, as well as two other files:\n",
+    "\n",
+    "1. A PROVN file describing the whole workflow and the programs we just ran.\n",
+    "\n",
+    "2. A .log file similar to the cell output you see above, describing each command that was run."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "But anyway, that's it for presets and workflows in BioProv. We hope this inspires you to create your own provenance-aware programs and workflows. If you do, share it with us! \n",
+    "\n",
+    "And if you think the workflow or preset you created would be useful to others, feel free to strike a conversation in our GitHub or open a new pull request."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:bioprov] *",
+   "language": "python",
+   "name": "conda-env-bioprov-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/docs/tutorials/w3c-prov.ipynb
+++ b/docs/tutorials/w3c-prov.ipynb
@@ -9,6 +9,7 @@
     "### Tutorial index\n",
     "* <a href=\"./introduction.ipynb\">Introduction to BioProv</a>\n",
     "* <a href=\"./w3c-prov.ipynb\">W3C-PROV projects</a>\n",
+    "* <a href=\"./workflows_and_presets.ipynb\">Presets and Workflows</a>\n",
     "\n",
     "## W3C-PROV workflows\n",
     "\n",
@@ -21,20 +22,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Project 'picocyano' with 5 samples"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import bioprov as bp\n",
     "from bioprov.data import picocyano_dataset\n",
@@ -51,42 +41,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "PosixPath('/Users/vini/anaconda3/envs/bp-use-case/lib/python3.8/site-packages/bioprov/data/datasets/picocyano.csv')"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "picocyano_dataset"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "sample-id,assembly,taxon\n",
-      "GCF_000010065.1,bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna,Synechococcus elongatus PCC 6301\n",
-      "GCF_000007925.1,bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic.fna,Prochlorococcus marinus CCMP1375\n",
-      "GCA_000316515.1,bioprov/data/genomes/GCF_000316515.1_ASM31651v1_genomic.fna,Cyanobium gracile PCC 6307\n",
-      "GCF_000012625.1,bioprov/data/genomes/GCF_000012625.1_ASM1262v1_genomic.fna,Parasynechococcus africanus CC9605\n",
-      "GCF_000011485.1,bioprov/data/genomes/GCF_000011485.1_ASM1148v1_genomic.fna,Thaumococcus swingsii MIT9313\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Take a peek at the file\n",
     "!cat ../../bioprov/data/datasets/picocyano.csv"
@@ -103,20 +69,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Project 'picocyano' with 5 samples"
-      ]
-     },
-     "execution_count": 4,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -141,21 +96,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{'GCF_000010065.1': Sample 'GCF_000010065.1' with 1 file(s)., 'GCF_000007925.1': Sample 'GCF_000007925.1' with 1 file(s)., 'GCA_000316515.1': Sample 'GCA_000316515.1' with 1 file(s)., 'GCF_000012625.1': Sample 'GCF_000012625.1' with 1 file(s)., 'GCF_000011485.1': Sample 'GCF_000011485.1' with 1 file(s).} \n",
-      "\n",
-      "{'assembly': /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna} \n",
-      "\n",
-      "{'assembly': '../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna', 'taxon': 'Synechococcus elongatus PCC 6301'}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj = bp.from_df(df, file_cols=[\"assembly\",], tag=\"picocyano\")\n",
     "\n",
@@ -174,20 +117,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Project 'W3C-PROV-tutorial.json' with 5 samples"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj = bp.read_csv(picocyano_dataset, file_cols=[\"assembly\",], tag=\"picocyano\")\n",
     "\n",
@@ -209,20 +141,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Project 'W3C-PROV-tutorial.json' with 5 samples"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = pd.read_csv(picocyano_dataset)\n",
     "df['assembly'] = \"../../\" + df[\"assembly\"]\n",
@@ -238,65 +159,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'path': PosixPath('/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna'),\n",
-       " 'name': 'GCF_000010065.1_ASM1006v1_genomic',\n",
-       " 'basename': 'GCF_000010065.1_ASM1006v1_genomic.fna',\n",
-       " 'directory': PosixPath('/Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes'),\n",
-       " 'extension': '.fna',\n",
-       " 'tag': 'assembly',\n",
-       " 'attributes': {},\n",
-       " '_exists': True,\n",
-       " '_size': '2.6 MB',\n",
-       " 'raw_size': 2730026,\n",
-       " '_sha256': '3a92f60662c48655d413ec017aaa2424128eb95882aa73005ec3bed266beba31',\n",
-       " '_entity': None,\n",
-       " 'format': 'fasta',\n",
-       " 'records': {'NC_006576.1': SeqRecord(seq=Seq('ATTTAAATCACTGGCATCAGCATTCGCAATATCATTGAGGTCAACAATACTTTC...GGC'), id='NC_006576.1', name='NC_006576.1', description='NC_006576.1 Synechococcus elongatus PCC 6301 DNA, complete genome', dbxrefs=[])},\n",
-       " '_generator': <Bio.SeqIO.FastaIO.FastaIterator at 0x7fdfbf427a00>,\n",
-       " '_seqstats': SeqStats(number_seqs=1, total_bps=2696255, mean_bp=2696255.0, min_bp=2696255, max_bp=2696255, N50=2696255, GC=0.55484),\n",
-       " '_parser': 'seq',\n",
-       " '_max_seq': None,\n",
-       " '_min_seq': None,\n",
-       " 'number_seqs': 1,\n",
-       " 'total_bps': 2696255,\n",
-       " 'mean_bp': 2696255.0,\n",
-       " 'min_bp': 2696255,\n",
-       " 'max_bp': 2696255,\n",
-       " 'N50': 2696255,\n",
-       " 'GC': 0.55484}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj[\"GCF_000010065.1\"].files['assembly'].__dict__"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "SeqStats(number_seqs=1, total_bps=2696255, mean_bp=2696255.0, min_bp=2696255, max_bp=2696255, N50=2696255, GC=0.55484)"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "proj[\"GCF_000010065.1\"].files['assembly'].seqstats"
    ]
@@ -312,66 +186,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Updating file proteins with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_proteins.faa.\n",
-      "Updating file genes with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_genes.fna.\n",
-      "Updating file scores with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_scores.cds.\n",
-      "Running program 'prodigal' for sample GCF_000010065.1.\n",
-      "Command is:\n",
-      "/Users/vini/anaconda3/envs/bp-use-case/bin/prodigal \\ \n",
-      "\t-i /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic.fna \\ \n",
-      "\t-a /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_proteins.faa \\ \n",
-      "\t-d /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_genes.fna \\ \n",
-      "\t-s /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000010065.1_ASM1006v1_genomic_scores.cds \n",
-      "Updating file proteins with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_proteins.faa.\n",
-      "Updating file genes with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_genes.fna.\n",
-      "Updating file scores with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_scores.cds.\n",
-      "Running program 'prodigal' for sample GCF_000007925.1.\n",
-      "Command is:\n",
-      "/Users/vini/anaconda3/envs/bp-use-case/bin/prodigal \\ \n",
-      "\t-i /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic.fna \\ \n",
-      "\t-a /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_proteins.faa \\ \n",
-      "\t-d /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_genes.fna \\ \n",
-      "\t-s /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000007925.1_ASM792v1_genomic_scores.cds \n",
-      "Updating file proteins with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000316515.1_ASM31651v1_genomic_proteins.faa.\n",
-      "Updating file genes with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000316515.1_ASM31651v1_genomic_genes.fna.\n",
-      "Updating file scores with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000316515.1_ASM31651v1_genomic_scores.cds.\n",
-      "Running program 'prodigal' for sample GCA_000316515.1.\n",
-      "Command is:\n",
-      "/Users/vini/anaconda3/envs/bp-use-case/bin/prodigal \\ \n",
-      "\t-i /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000316515.1_ASM31651v1_genomic.fna \\ \n",
-      "\t-a /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000316515.1_ASM31651v1_genomic_proteins.faa \\ \n",
-      "\t-d /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000316515.1_ASM31651v1_genomic_genes.fna \\ \n",
-      "\t-s /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000316515.1_ASM31651v1_genomic_scores.cds \n",
-      "Updating file proteins with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000012625.1_ASM1262v1_genomic_proteins.faa.\n",
-      "Updating file genes with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000012625.1_ASM1262v1_genomic_genes.fna.\n",
-      "Updating file scores with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000012625.1_ASM1262v1_genomic_scores.cds.\n",
-      "Running program 'prodigal' for sample GCF_000012625.1.\n",
-      "Command is:\n",
-      "/Users/vini/anaconda3/envs/bp-use-case/bin/prodigal \\ \n",
-      "\t-i /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000012625.1_ASM1262v1_genomic.fna \\ \n",
-      "\t-a /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000012625.1_ASM1262v1_genomic_proteins.faa \\ \n",
-      "\t-d /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000012625.1_ASM1262v1_genomic_genes.fna \\ \n",
-      "\t-s /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000012625.1_ASM1262v1_genomic_scores.cds \n",
-      "Updating file proteins with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000011485.1_ASM1148v1_genomic_proteins.faa.\n",
-      "Updating file genes with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000011485.1_ASM1148v1_genomic_genes.fna.\n",
-      "Updating file scores with value /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000011485.1_ASM1148v1_genomic_scores.cds.\n",
-      "Running program 'prodigal' for sample GCF_000011485.1.\n",
-      "Command is:\n",
-      "/Users/vini/anaconda3/envs/bp-use-case/bin/prodigal \\ \n",
-      "\t-i /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000011485.1_ASM1148v1_genomic.fna \\ \n",
-      "\t-a /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000011485.1_ASM1148v1_genomic_proteins.faa \\ \n",
-      "\t-d /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000011485.1_ASM1148v1_genomic_genes.fna \\ \n",
-      "\t-s /Users/vini/Bio/BioProv/docs/tutorials/../../bioprov/data/genomes/GCF_000011485.1_ASM1148v1_genomic_scores.cds \n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "from bioprov.programs import prodigal\n",
     "\n",
@@ -389,52 +206,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mInit signature:\u001b[0m\n",
-       "\u001b[0mbp\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPresetProgram\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mparams\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0msample\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0minput_files\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0moutput_files\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mpreffix_tag\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mextra_flags\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-       "\u001b[0;31mDocstring:\u001b[0m     \n",
-       "Class for holding a preset program and related functions.\n",
-       "\n",
-       "A WorkflowStep instance inherits from Program and consists of an instance\n",
-       "of Program with an associated instance of Sample or Project.\n",
-       "\u001b[0;31mInit docstring:\u001b[0m\n",
-       ":param name: Instance of bioprov.Program\n",
-       ":param params: Dictionary of parameters.\n",
-       ":param sample: An instance of Sample or Project.\n",
-       ":param input_files: A dictionary consisting of Parameter keys as keys and a File.tag\n",
-       "                    as value, where File.tag is a string that must be a key in\n",
-       "                    self.sample.files with a corresponding existing file.\n",
-       ":param output_files: A dictionary consisting of Parameter keys as keys and a tuple\n",
-       "                     consisting of (File.tag, suffix) as value.\n",
-       "                     File.tag will become a key in self.sample.files and the its value\n",
-       "                     will be the sample_name + suffix.\n",
-       ":param preffix_tag: A value in the input_files argument, which corresponds\n",
-       "                    to a key in self.sample.files. All file names of output\n",
-       "                    files will be stemmed from this file, hence 'preffix'.\n",
-       ":param extra_flags: A list of command line parameters (strings), known as flags or\n",
-       "                    switches, to add to the program's command.\n",
-       "\u001b[0;31mFile:\u001b[0m           ~/anaconda3/envs/bp-use-case/lib/python3.8/site-packages/bioprov/src/main.py\n",
-       "\u001b[0;31mType:\u001b[0m           type\n",
-       "\u001b[0;31mSubclasses:\u001b[0m     \n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "bp.PresetProgram?"
    ]
@@ -450,7 +224,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,17 +240,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Project 'W3C-PROV-tutorial.json' with 5 samples\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(prov.project)"
    ]
@@ -494,43 +260,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PROV-N \n",
-      "\n",
-      " document\n",
-      "  prefix project <Project 'W3C-PROV-tutorial.json' with 5 samples>\n",
-      "  prefix users <Users associated with BioProv Project 'W3C-PROV-tutorial.json'>\n",
-      "  prefix samples <Samples associated with bioprov Project 'W3C-PROV-tutorial.json'>\n",
-      "  \n",
-      "  bundle users:vini\n",
-      "    default <vini>\n",
-      "    prefix envs <Environments associated with User 'vini'>\n",
-      "    prefix users <Users associated with BioProv Project 'W3C-PROV-tutorial.json'>\n",
-      "    \n",
-      "    agent(users:vini)\n",
-      "    agent(envs:c4c5922f6c7d7c0206378e3708ab74fe4c44d841dec96549484bc3842333bed8)\n",
-      "    actedOnBehalfOf(envs:c4c5922f6c7d7c0206378e3708ab74fe4c44d841dec96549484bc3842333bed8, users:vini, -)\n",
-      "  endBundle\n",
-      "  bundle project:Project 'W3C-PROV-tutorial.json' with 5 samples\n",
-      "    default <W3C-PROV-tutorial.json>\n",
-      "    prefix files <Files associated with Project W3C-PROV-tutorial.json>\n",
-      "    prefix programs <Programs associated with Project W3C-PROV-tutorial.json>\n",
-      "    \n",
-      "    entity(project:Project 'W3C-PROV-tutorial.json' with 5 samples)\n",
-      "  endBundle\n",
-      "  bundle sampl\n",
-      "PROV-JSON \n",
-      "\n",
-      " {\"prefix\": {\"project\": \"Project 'W3C-PROV-tutorial.json' with 5 samples\", \"users\": \"Users associated with BioProv Project 'W3C-PROV-tutorial.json'\", \"samples\": \"Samples associated with bioprov Project 'W3C-PROV-tutorial.json'\"}, \"bundle\": {\"users:vini\": {\"prefix\": {\"envs\": \"Environments associated with User 'vini'\", \"users\": \"Users associated with BioProv Project 'W3C-PROV-tutorial.json'\", \"default\": \"vini\"}, \"agent\": {\"users:vini\": {}, \"envs:c4c5922f6c7d7c0206378e3708ab74fe4c44d841dec96549484bc3842333bed8\": {}}, \"actedOnBehalfOf\": {\"_:id1\": {\"prov:delegate\": \"envs:c4c5922f6c7d7c0206378e3708ab74fe4c44d841dec96549484bc3842333bed8\", \"prov:responsible\": \"users:vini\"}}}, \"project:Project 'W3C-PROV-tutorial.json' with 5 samples\": {\"prefix\": {\"files\": \"Files associated with Project W3C-PROV-tutorial.json\", \"programs\": \"Programs associated with Project W3C-PROV-tutorial.json\", \"default\": \"W3C-PROV-tutorial.json\"}, \"entity\": {\"project:Project 'W3C-PROV-tutorial.json' with 5 samples\": {}}}, \"sa\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "print(\"PROV-N\", \"\\n\\n\", prov.ProvDocument.get_provn()[:1000])\n",
     "print(\"PROV-JSON\", \"\\n\\n\", prov.ProvDocument.serialize()[:1000])\n",
@@ -552,9 +284,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:bp-use-case]",
+   "display_name": "Python [conda env:bioprov] *",
    "language": "python",
-   "name": "conda-env-bp-use-case-py"
+   "name": "conda-env-bioprov-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -566,7 +298,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.7.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changes made:

- Adds a Jupyter Notebook tutorial for building PresetPrograms and Workflows
- Also updates the table of contents in the other tutorials.
- Adds the outputs of the presets_and_workflows tutorial to the gitignore
(to avoid cluttering).
