### PR TITLE
Fix top-level docstrings

### DIFF
--- a/bioprov/__init__.py
+++ b/bioprov/__init__.py
@@ -1,15 +1,14 @@
+"""
+Init module for package bioprov.
+
+Inherits objects from the src/ package.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-
-"""
-Init module for package bioprov.
-
-Inherits objects from the src/ package.
-"""
 
 from .src.config import config, Environment, BioProvDB, Config
 from .src.files import File, SeqFile, Directory

--- a/bioprov/__init__.py
+++ b/bioprov/__init__.py
@@ -1,13 +1,13 @@
-"""
-Init module for package bioprov.
-
-Inherits objects from the src/ package.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Init module for package bioprov.
+
+Inherits objects from the src/ package.
+"""
 
 
 from .src.config import config, Environment, BioProvDB, Config

--- a/bioprov/bioprov.py
+++ b/bioprov/bioprov.py
@@ -1,11 +1,11 @@
-"""
-BioProv command-line application. This module holds the main executable.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+BioProv command-line application. This module holds the main executable.
+"""
 
 
 import argparse

--- a/bioprov/bioprov.py
+++ b/bioprov/bioprov.py
@@ -1,12 +1,12 @@
+"""
+BioProv command-line application. This module holds the main executable.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-"""
-BioProv command-line application. This module holds the main executable.
-"""
 
 import argparse
 import sys

--- a/bioprov/data/__init__.py
+++ b/bioprov/data/__init__.py
@@ -1,13 +1,12 @@
+"""
+Contains example and test data.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-
-"""
-Contains example and test data.
-"""
 
 from pathlib import Path
 

--- a/bioprov/data/__init__.py
+++ b/bioprov/data/__init__.py
@@ -1,11 +1,11 @@
-"""
-Contains example and test data.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Contains example and test data.
+"""
 
 
 from pathlib import Path

--- a/bioprov/programs/programs.py
+++ b/bioprov/programs/programs.py
@@ -1,11 +1,11 @@
-"""
-Module for holding preset instances of the Program class.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Module for holding preset instances of the Program class.
+"""
 
 
 from os import path

--- a/bioprov/programs/programs.py
+++ b/bioprov/programs/programs.py
@@ -1,14 +1,12 @@
+"""
+Module for holding preset instances of the Program class.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-
-"""
-Module for holding preset instances of the Program class.
-Module for holding preset instances of the Program class.
-"""
 
 from os import path
 from pathlib import Path

--- a/bioprov/programs/programs.py
+++ b/bioprov/programs/programs.py
@@ -265,7 +265,7 @@ def prokka(
     :param contigs: Output contigs.
     :param genes: Output genes.
     :param proteins: Output proteins.
-    :param feature_table Output feature table.
+    :param feature_table: Output feature table.
     :param submit_contigs: Output contigs formatted for NCBI submission.
     :param sequin: Output sequin file.
     :param genbank: Output genbank .gbk file

--- a/bioprov/src/__init__.py
+++ b/bioprov/src/__init__.py
@@ -1,10 +1,9 @@
+"""
+Init file for the src/ package.
+"""
+
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
-
-
-"""
-Init file for the src/ package.
-"""

--- a/bioprov/src/__init__.py
+++ b/bioprov/src/__init__.py
@@ -1,9 +1,8 @@
-"""
-Init file for the src/ package.
-"""
-
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Init file for the src/ package.
+"""

--- a/bioprov/src/config.py
+++ b/bioprov/src/config.py
@@ -1,15 +1,15 @@
+"""
+Contains the Config class and other package-level settings.
+
+Define your configurations in the 'config' variable at the end of the module.
+"""
+
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-
-"""
-Contains the Config class and other package-level settings.
-
-Define your configurations in the 'config' variable at the end of the module.
-"""
 
 import os
 from pathlib import Path

--- a/bioprov/src/config.py
+++ b/bioprov/src/config.py
@@ -1,14 +1,13 @@
-"""
-Contains the Config class and other package-level settings.
-
-Define your configurations in the 'config' variable at the end of the module.
-"""
-
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Contains the Config class and other package-level settings.
+
+Define your configurations in the 'config' variable at the end of the module.
+"""
 
 
 import os

--- a/bioprov/src/files.py
+++ b/bioprov/src/files.py
@@ -1,13 +1,12 @@
+"""
+Contains the File and SeqFile classes and related functions.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-
-"""
-Contains the File and SeqFile classes and related functions.
-"""
 
 import logging
 from dataclasses import dataclass

--- a/bioprov/src/files.py
+++ b/bioprov/src/files.py
@@ -1,11 +1,11 @@
-"""
-Contains the File and SeqFile classes and related functions.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Contains the File and SeqFile classes and related functions.
+"""
 
 
 import logging

--- a/bioprov/src/main.py
+++ b/bioprov/src/main.py
@@ -797,9 +797,10 @@ def generate_param_str(params):
 def _add_programs(object_, programs):
     """
     Adds program(s) to object. Must be an instance or iterable of bioprov.Program.
+
     :param object_: A bioprov.Sample or Project instance.
     :param programs: bioprov.Program iterator or instance, value where key is the program name
-                     and value is a bp.Program instance.
+    and value is a bp.Program instance.
     :return: Updates self by adding the programs to object.
     """
 
@@ -950,8 +951,9 @@ class Sample:
     def add_programs(self, programs):
         """
         Adds program(s) to self. Must be an instance or iterable of bioprov.Program.
+
         :param programs: bioprov.Program iterator or instance, value where key is the program name
-                         and value is a bp.Program instance.
+            and value is a bp.Program instance.
         :return: Updates self by adding the programs to object.
         """
         _add_programs(self, programs)
@@ -1072,9 +1074,9 @@ class Project:
         :param tag: A tag to describe the Project.
         :param db: path to TinyDB to store project in JSON format.
         :param auto_update: Whether to auto_update the BioProvDB record.
-                            Disabled by default.
+        Disabled by default.
         :param log_to_file: Whether to log the Project to a File. You can define this later with
-                            the self.start_logging() method.
+        the self.start_logging() method.
         """
         if tag is None:
             slug = generate_slug(2)
@@ -1601,17 +1603,20 @@ def from_df(
     Pandas-like function to build a Project object.
 
     By default, assumes the sample names or ids are in the first column,
-        else they should be specified by 'index_col' arg.
+    else they should be specified by 'index_col' arg.
+
     '''
     samples = from_df(df_path, sep="\t")
 
     type(samples)  # bioprov.Sample.Project.
 
     You can select columns to be added as Files or SequenceFile instances.
+
     '''
+
     :param df: A pandas DataFrame
     :param index_col: A column to be used as index. Must be in df_path.columns.
-                        If int is passed, will get it from columns.
+        If int is passed, will get it from columns.
     :param file_cols: Columns containing Files.
     :param sequencefile_cols: Columns containing SequenceFiles.
     :param tag: A tag to describe the Project.

--- a/bioprov/src/main.py
+++ b/bioprov/src/main.py
@@ -1,4 +1,9 @@
-"""
+__author__ = "Vini Salazar"
+__license__ = "MIT"
+__maintainer__ = "Vini Salazar"
+__url__ = "https://github.com/vinisalazar/bioprov"
+__version__ = "0.1.24"
+__doc__ = """
 
 Main source module. Contains the main BioProv classes.
 
@@ -15,11 +20,6 @@ Entity classes:
 This class also contains functions to read and write objects in JSON and tab-delimited formats.
 
 """
-__author__ = "Vini Salazar"
-__license__ = "MIT"
-__maintainer__ = "Vini Salazar"
-__url__ = "https://github.com/vinisalazar/bioprov"
-__version__ = "0.1.24"
 
 
 import datetime

--- a/bioprov/src/main.py
+++ b/bioprov/src/main.py
@@ -1,9 +1,3 @@
-__author__ = "Vini Salazar"
-__license__ = "MIT"
-__maintainer__ = "Vini Salazar"
-__url__ = "https://github.com/vinisalazar/bioprov"
-__version__ = "0.1.24"
-
 """
 
 Main source module. Contains the main BioProv classes.
@@ -21,6 +15,12 @@ Entity classes:
 This class also contains functions to read and write objects in JSON and tab-delimited formats.
 
 """
+__author__ = "Vini Salazar"
+__license__ = "MIT"
+__maintainer__ = "Vini Salazar"
+__url__ = "https://github.com/vinisalazar/bioprov"
+__version__ = "0.1.24"
+
 
 import datetime
 import json

--- a/bioprov/src/prov.py
+++ b/bioprov/src/prov.py
@@ -1,15 +1,15 @@
-__author__ = "Vini Salazar"
-__license__ = "MIT"
-__maintainer__ = "Vini Salazar"
-__url__ = "https://github.com/vinisalazar/bioprov"
-__version__ = "0.1.24"
-
 """
 Module containing base provenance attributes.
 
 This module extracts system-level information, such as user and environment
 settings, and stores them. It is invoked to export provenance objects. 
 """
+__author__ = "Vini Salazar"
+__license__ = "MIT"
+__maintainer__ = "Vini Salazar"
+__url__ = "https://github.com/vinisalazar/bioprov"
+__version__ = "0.1.24"
+
 import logging
 from pathlib import Path
 

--- a/bioprov/src/prov.py
+++ b/bioprov/src/prov.py
@@ -1,14 +1,14 @@
-"""
-Module containing base provenance attributes.
-
-This module extracts system-level information, such as user and environment
-settings, and stores them. It is invoked to export provenance objects. 
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Module containing base provenance attributes.
+
+This module extracts system-level information, such as user and environment
+settings, and stores them. It is invoked to export provenance objects. 
+"""
 
 import logging
 from pathlib import Path

--- a/bioprov/src/workflow.py
+++ b/bioprov/src/workflow.py
@@ -1,12 +1,12 @@
+"""
+Contains the Workflow class and related functions.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-"""
-Contains the Workflow class and related functions.
-"""
 
 import argparse
 import logging

--- a/bioprov/src/workflow.py
+++ b/bioprov/src/workflow.py
@@ -1,11 +1,11 @@
-"""
-Contains the Workflow class and related functions.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Contains the Workflow class and related functions.
+"""
 
 
 import argparse

--- a/bioprov/tests/__init__.py
+++ b/bioprov/tests/__init__.py
@@ -1,10 +1,8 @@
+"""
+Init file for the tests/ package.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
-
-
-"""
-Init file for the tests/ package.
-"""

--- a/bioprov/tests/__init__.py
+++ b/bioprov/tests/__init__.py
@@ -1,8 +1,8 @@
-"""
-Init file for the tests/ package.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Init file for the tests/ package.
+"""

--- a/bioprov/tests/test_bioprov_imports.py
+++ b/bioprov/tests/test_bioprov_imports.py
@@ -1,15 +1,15 @@
-"""
+__author__ = "Vini Salazar"
+__license__ = "MIT"
+__maintainer__ = "Vini Salazar"
+__url__ = "https://github.com/vinisalazar/bioprov"
+__version__ = "0.1.24"
+__doc__ = """
 Testing module for the package BioProv.
 
 Tests include:
     - Imports;
     - Class generation and methods.
 """
-__author__ = "Vini Salazar"
-__license__ = "MIT"
-__maintainer__ = "Vini Salazar"
-__url__ = "https://github.com/vinisalazar/bioprov"
-__version__ = "0.1.24"
 
 
 def test_import_bioprov():

--- a/bioprov/tests/test_bioprov_imports.py
+++ b/bioprov/tests/test_bioprov_imports.py
@@ -1,10 +1,3 @@
-__author__ = "Vini Salazar"
-__license__ = "MIT"
-__maintainer__ = "Vini Salazar"
-__url__ = "https://github.com/vinisalazar/bioprov"
-__version__ = "0.1.24"
-
-
 """
 Testing module for the package BioProv.
 
@@ -12,6 +5,11 @@ Tests include:
     - Imports;
     - Class generation and methods.
 """
+__author__ = "Vini Salazar"
+__license__ = "MIT"
+__maintainer__ = "Vini Salazar"
+__url__ = "https://github.com/vinisalazar/bioprov"
+__version__ = "0.1.24"
 
 
 def test_import_bioprov():

--- a/bioprov/tests/test_bioprov_integration.py
+++ b/bioprov/tests/test_bioprov_integration.py
@@ -1,11 +1,11 @@
-"""
-Integration testing for drafting new ideas.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Integration testing for drafting new ideas.
+"""
 
 
 from argparse import Namespace

--- a/bioprov/tests/test_bioprov_integration.py
+++ b/bioprov/tests/test_bioprov_integration.py
@@ -1,13 +1,12 @@
+"""
+Integration testing for drafting new ideas.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-
-"""
-Integration testing for drafting new ideas.
-"""
 
 from argparse import Namespace
 from os import remove

--- a/bioprov/tests/test_bioprov_programs.py
+++ b/bioprov/tests/test_bioprov_programs.py
@@ -1,11 +1,11 @@
-"""
-Testing for the programs package.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Testing for the programs package.
+"""
 
 
 from bioprov import Sample

--- a/bioprov/tests/test_bioprov_programs.py
+++ b/bioprov/tests/test_bioprov_programs.py
@@ -1,13 +1,12 @@
+"""
+Testing for the programs package.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-
-"""
-Testing for the programs package.
-"""
 
 from bioprov import Sample
 from bioprov.data import synechococcus_genome

--- a/bioprov/tests/test_bioprov_workflows.py
+++ b/bioprov/tests/test_bioprov_workflows.py
@@ -1,11 +1,11 @@
-"""
-Testing for the workflows package.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Testing for the workflows package.
+"""
 
 
 from os import remove

--- a/bioprov/tests/test_bioprov_workflows.py
+++ b/bioprov/tests/test_bioprov_workflows.py
@@ -1,3 +1,6 @@
+"""
+Testing for the workflows package.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
@@ -5,9 +8,6 @@ __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
 
-"""
-Testing for the workflows package.
-"""
 from os import remove
 from pathlib import Path
 from bioprov.data import genome_annotation_dataset

--- a/bioprov/tests/test_src_config.py
+++ b/bioprov/tests/test_src_config.py
@@ -1,13 +1,12 @@
+"""
+Testing for the Config module.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-
-"""
-Testing for the Config module.
-"""
 
 from os import environ, remove
 from pathlib import Path

--- a/bioprov/tests/test_src_config.py
+++ b/bioprov/tests/test_src_config.py
@@ -1,11 +1,11 @@
-"""
-Testing for the Config module.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Testing for the Config module.
+"""
 
 
 from os import environ, remove

--- a/bioprov/tests/test_src_file.py
+++ b/bioprov/tests/test_src_file.py
@@ -1,11 +1,11 @@
-"""
-Testing for the File module.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Testing for the File module.
+"""
 
 
 from pathlib import Path

--- a/bioprov/tests/test_src_file.py
+++ b/bioprov/tests/test_src_file.py
@@ -1,3 +1,6 @@
+"""
+Testing for the File module.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
@@ -5,9 +8,6 @@ __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
 
-"""
-Testing for the File module.
-"""
 from pathlib import Path
 
 from coolname import generate_slug

--- a/bioprov/tests/test_src_file.py
+++ b/bioprov/tests/test_src_file.py
@@ -25,6 +25,7 @@ def test_File_and_Directory():
         - existing File instance
         - non-existing File instance
         - get_size(), convert_bytes()
+
     :return:
     """
 

--- a/bioprov/tests/test_src_main.py
+++ b/bioprov/tests/test_src_main.py
@@ -1,10 +1,3 @@
-__author__ = "Vini Salazar"
-__license__ = "MIT"
-__maintainer__ = "Vini Salazar"
-__url__ = "https://github.com/vinisalazar/bioprov"
-__version__ = "0.1.24"
-
-
 """
 Testing for the bioprov.src.main module.
  Tests the following classes:
@@ -16,6 +9,12 @@ Testing for the bioprov.src.main module.
     
  Also tests JSON and tab-delimited serializer methods.
 """
+__author__ = "Vini Salazar"
+__license__ = "MIT"
+__maintainer__ = "Vini Salazar"
+__url__ = "https://github.com/vinisalazar/bioprov"
+__version__ = "0.1.24"
+
 
 # TODO: organize this
 import datetime

--- a/bioprov/tests/test_src_main.py
+++ b/bioprov/tests/test_src_main.py
@@ -1,4 +1,9 @@
-"""
+__author__ = "Vini Salazar"
+__license__ = "MIT"
+__maintainer__ = "Vini Salazar"
+__url__ = "https://github.com/vinisalazar/bioprov"
+__version__ = "0.1.24"
+__doc__ = """
 Testing for the bioprov.src.main module.
  Tests the following classes:
     - Program
@@ -9,11 +14,6 @@ Testing for the bioprov.src.main module.
     
  Also tests JSON and tab-delimited serializer methods.
 """
-__author__ = "Vini Salazar"
-__license__ = "MIT"
-__maintainer__ = "Vini Salazar"
-__url__ = "https://github.com/vinisalazar/bioprov"
-__version__ = "0.1.24"
 
 
 # TODO: organize this

--- a/bioprov/tests/test_src_prov.py
+++ b/bioprov/tests/test_src_prov.py
@@ -1,14 +1,13 @@
+"""
+Testing for prov module.
+    - BioProvDocument class
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-
-"""
-Testing for prov module.
-    - BioProvDocument class
-"""
 
 from os import environ
 

--- a/bioprov/tests/test_src_prov.py
+++ b/bioprov/tests/test_src_prov.py
@@ -1,12 +1,12 @@
-"""
-Testing for prov module.
-    - BioProvDocument class
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Testing for prov module.
+    - BioProvDocument class
+"""
 
 
 from os import environ

--- a/bioprov/utils.py
+++ b/bioprov/utils.py
@@ -1,11 +1,11 @@
-"""
-Helper functions.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Helper functions.
+"""
 
 import hashlib
 import io

--- a/bioprov/utils.py
+++ b/bioprov/utils.py
@@ -1,12 +1,12 @@
+"""
+Helper functions.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-"""
-Helper functions.
-"""
 import hashlib
 import io
 import json

--- a/bioprov/workflows/workflows.py
+++ b/bioprov/workflows/workflows.py
@@ -1,12 +1,12 @@
+"""
+Module containing preset workflows created with the Workflow class.
+"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
 
-"""
-Module containing preset workflows created with the Workflow class.
-"""
 
 from bioprov.programs import blastn, prodigal
 from bioprov.src.workflow import Workflow, Step

--- a/bioprov/workflows/workflows.py
+++ b/bioprov/workflows/workflows.py
@@ -1,11 +1,11 @@
-"""
-Module containing preset workflows created with the Workflow class.
-"""
 __author__ = "Vini Salazar"
 __license__ = "MIT"
 __maintainer__ = "Vini Salazar"
 __url__ = "https://github.com/vinisalazar/bioprov"
 __version__ = "0.1.24"
+__doc__ = """
+Module containing preset workflows created with the Workflow class.
+"""
 
 
 from bioprov.programs import blastn, prodigal

--- a/docs/source/bioprov.workflows.rst
+++ b/docs/source/bioprov.workflows.rst
@@ -4,6 +4,14 @@ bioprov.workflows package
 Submodules
 ----------
 
+bioprov.workflows.blastn\_alignment module
+-------------------------------------------
+
+.. automodule:: bioprov.workflows.blastn_alignment
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 bioprov.workflows.genome\_annotation module
 -------------------------------------------
 
@@ -12,18 +20,18 @@ bioprov.workflows.genome\_annotation module
    :undoc-members:
    :show-inheritance:
 
-bioprov.workflows.kaiju module
-------------------------------
+bioprov.workflows.KaijuWorkflow module
+--------------------------------------
 
-.. automodule:: bioprov.workflows.kaiju
+.. automodule:: bioprov.workflows.KaijuWorkflow
    :members:
    :undoc-members:
    :show-inheritance:
 
-bioprov.workflows.wf\_parser module
------------------------------------
+bioprov.workflows.WorkflowOptionsParser module
+----------------------------------------------
 
-.. automodule:: bioprov.workflows.wf_parser
+.. automodule:: bioprov.workflows.WorkflowOptionsParser
    :members:
    :undoc-members:
    :show-inheritance:
@@ -31,7 +39,7 @@ bioprov.workflows.wf\_parser module
 Module contents
 ---------------
 
-.. automodule:: bioprov.workflows
+.. automodule:: bioprov.workflows.workflows
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
Changes made:
- docs: Fix top-level docstrings for src
- docs: Fix top-level docstrings for data
- docs: Fix top-level docstrings for programs
- docs: Fix top-level docstrings for tests
- docs: Fix top-level docstrings for workflows
- docs: Fix top-level docstrings for base package
- docs: Fix some other sphinx warnings

While most warnings I got using `make html` I managed to fix, 
some parts of the documentation are still getting broken because some functions take in `object_` as an argument but sphinx recognizes text ending with _ as references so it breaks the docstring. 
That's something to refactor in the future.
