### PR TITLE
fix: Make Program attrs return None not error

### DIFF
--- a/bioprov/src/main.py
+++ b/bioprov/src/main.py
@@ -114,56 +114,56 @@ class Program:
     def stdin(self):
         try:
             return self.runs[list(self.runs.keys())[-1]].stdin
-        except KeyError:
+        except (KeyError, IndexError):
             return None
 
     @property
     def stdout(self):
         try:
             return self.runs[list(self.runs.keys())[-1]].stdout
-        except KeyError:
+        except (KeyError, IndexError):
             return None
 
     @property
     def stderr(self):
         try:
             return self.runs[list(self.runs.keys())[-1]].stderr
-        except KeyError:
+        except (KeyError, IndexError):
             return None
 
     @property
     def start_time(self):
         try:
             return self.runs[list(self.runs.keys())[-1]].start_time
-        except KeyError:
+        except (KeyError, IndexError):
             return None
 
     @property
     def end_time(self):
         try:
             return self.runs[list(self.runs.keys())[-1]].end_time
-        except KeyError:
+        except (KeyError, IndexError):
             return None
 
     @property
     def duration(self):
         try:
             return self.runs[list(self.runs.keys())[-1]].duration
-        except KeyError:
+        except (KeyError, IndexError):
             return None
 
     @property
     def finished(self):
         try:
             return self.runs[list(self.runs.keys())[-1]].finished
-        except KeyError:
+        except (KeyError, IndexError):
             return None
 
     @property
     def status(self):
         try:
             return self.runs[list(self.runs.keys())[-1]].status
-        except KeyError:
+        except (KeyError, IndexError):
             return None
 
     def add_runs(self, runs):

--- a/bioprov/tests/test_src_main.py
+++ b/bioprov/tests/test_src_main.py
@@ -125,6 +125,27 @@ def test_Run():
     assert str(run_).startswith("Run")
 
 
+def test_empty_runs_attr():
+    """
+    Tests if, when runs is empty, dependent attributes return None
+    """
+
+    grep = Program("grep")
+
+    depends_on_runs = [
+        grep.stdout,
+        grep.stdin,
+        grep.stderr,
+        grep.start_time,
+        grep.end_time,
+        grep.duration,
+        grep.finished,
+        grep.status,
+    ]
+
+    assert all(attr is None for attr in depends_on_runs) == True
+
+
 def test_parse_params():
     """
     Testing for the parse_params() function.


### PR DESCRIPTION
Changes made:
- Fix bug related to Program attributes that depend on the runs attribute
- Add a test for said fix

Before, when a user tried to access Program attributes that depend on
runs and runs is None, BioProv would error out, now we account for runs
being none.
